### PR TITLE
Keep focus points replace

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,9 @@
-The MIT License (MIT)
+Shake License 1.0
 
-Copyright (c) 2023 Menglin "Mark" Xu <mark@remarkablemark.org>
+Copyright (c) 2025 Jyrone "Mastashake" Parker <jyrone@jyroneparker.com>
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+This software is free to use for hobbyist programmers and developers, free of charge, provided that proper attribution is given to the original author.
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+Any commercial use of this software is strictly prohibited without a separate license contract. For commercial licensing, please contact the author.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-
 # ShakeFace
 
-**ShakeFace** is a JavaScript library that leverages facial detection and image processing to apply custom filters to detected faces in images or video streams. It builds upon the native `FaceDetector` API, providing real-time face detection and a suite of customizable filter options.
+**ShakeFace** is a JavaScript library for real-time face detection and creative face filtering in images and video streams. Built on top of the native `FaceDetector` API, ShakeFace makes it easy to apply custom filters, effects, and face replacements with a simple, modern API.
+
+---
 
 ## Table of Contents
 
@@ -13,25 +14,31 @@
   - [Applying Filters](#applying-filters)
   - [Custom Events](#custom-events)
 - [API Reference](#api-reference)
-  - [ShakeFace](#shakeface)
-  - [ShakeFaceEvent](#shakefaceevent)
 - [Examples](#examples)
 - [Social Media](#social-media)
 - [License](#license)
 
+---
+
 ## Features
 
-- **Real-time face detection**: Detect faces in images or video streams using custom `TransformStreams`.
-- **Filter Application**: Apply a range of filters to detected faces, such as color pop, tracking outlines, Gaussian blur, and face replacement.
-- **Event Handling**: Use `ShakeFaceEvent` for custom event management.
+- **Real-time face detection** using the browser's FaceDetector API.
+- **Flexible filter application**: Color pop, tracking outlines, Gaussian blur, face replacement, and more.
+- **Stream support**: Use with video streams via `TransformStream`.
+- **Custom event handling** for robust error and state management.
+- **Easy integration** with modern JavaScript projects.
+
+---
 
 ## Installation
 
-To use ShakeFace, install the package via npm:
+Install ShakeFace via npm:
 
 ```bash
 npm install @mastashake08/shake-face
 ```
+
+---
 
 ## Usage
 
@@ -40,7 +47,7 @@ npm install @mastashake08/shake-face
 ```javascript
 import ShakeFace from '@mastashake08/shake-face';
 
-const imageElement = document.getElementById('myImage'); // or any HTMLImageElement
+const imageElement = document.getElementById('myImage');
 const shakeFace = new ShakeFace(imageElement, {
     maxDetectedFaces: 5,
     fastMode: false
@@ -49,7 +56,7 @@ const shakeFace = new ShakeFace(imageElement, {
 
 ### Real-Time Detection
 
-You can detect faces in real time using `detectStream()` for live face detection or `addFilterStream()` to apply filters directly on video frames.
+Detect faces in real time from a video stream:
 
 ```javascript
 const detectStream = ShakeFace.detectStream();
@@ -58,23 +65,18 @@ const filterStream = shakeFace.addFilterStream('colorPop');
 
 ### Applying Filters
 
-ShakeFace allows you to apply several built-in filters:
-
-- **Color Pop**: Makes the background grayscale, keeping faces in color.
-- **Tracking Outline**: Adds an outline around detected faces.
-- **Gaussian Blur**: Blurs detected faces.
-- **Face Replacement**: Replaces a detected face with a provided image.
+Apply built-in filters to detected faces:
 
 ```javascript
-shakeFace.colorPop(imageElement);
-shakeFace.track(face, { stroke: 'blue', lineWidth: 4 });
-shakeFace.blur(face, 10);
-shakeFace.replace(face, replacementImage);
+shakeFace.colorPop(imageElement); // Background grayscale, faces in color
+shakeFace.track(face, { stroke: 'blue', lineWidth: 4 }); // Outline
+shakeFace.blur(face, 10); // Blur face
+shakeFace.replace(face, replacementImage, true); // Replace face, keep eyes/mouth
 ```
 
 ### Custom Events
 
-`ShakeFaceEvent` allows handling custom events, which is useful for handling errors or other states in the face detection process.
+Handle errors and custom events:
 
 ```javascript
 shakeFace.addEventListener('error', (event) => {
@@ -82,14 +84,16 @@ shakeFace.addEventListener('error', (event) => {
 });
 ```
 
+---
+
 ## API Reference
 
 ### ShakeFace
 
 #### `constructor(image, options)`
 
-- **`image`**: `HTMLImageElement` to be used for face detection.
-- **`options`**: Configuration options for face detection.
+- `image`: `HTMLImageElement` for face detection (optional).
+- `options`: `{ maxDetectedFaces, fastMode }` (optional).
 
 #### `detect(image)`
 
@@ -101,41 +105,69 @@ Returns a `TransformStream` for real-time face detection on video frames.
 
 #### `addFilterStream(filter)`
 
-Applies the specified filter to faces in a video stream.
+Returns a `TransformStream` that applies the specified filter to faces in a video stream.
+
+#### `colorPop(image)`
+
+Applies a grayscale background, keeping faces in color.
+
+#### `track(face, options)`
+
+Draws an outline around the detected face.
+
+#### `blur(face, blurRadius)`
+
+Applies a Gaussian blur to the detected face.
+
+#### `replace(face, image, keepLandmarks)`
+
+Replaces a detected face with a provided image. If `keepLandmarks` is `true`, the original eyes and mouth are preserved.
+
+---
 
 ### ShakeFaceEvent
 
-Custom event class for handling ShakeFace-related events.
+Custom event class for ShakeFace events.
 
 #### `constructor(type, eventData, options)`
 
-- **`type`**: Type of event.
-- **`eventData`**: Additional data for the event.
-- **`options`**: Options for the event.
+- `type`: Event type.
+- `eventData`: Additional data.
+- `options`: Event options.
+
+---
 
 ## Examples
 
-Apply a color pop filter to an image:
+Apply a color pop filter:
 
 ```javascript
 shakeFace.colorPop();
 ```
 
-Track a face in an image:
+Track a face:
 
 ```javascript
 shakeFace.track(face, { stroke: 'green', lineWidth: 2 });
 ```
 
-Blur a detected face:
+Blur a face:
 
 ```javascript
 shakeFace.blur(face, 5);
 ```
 
+Replace a face but keep the user's eyes and mouth:
+
+```javascript
+shakeFace.replace(face, replacementImage, true);
+```
+
+---
+
 ## Social Media
 
-Connect with me on social media:
+Connect with the author:
 
 - [![TikTok](https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white)](https://www.tiktok.com/@jyroneparker)
 - [![Instagram](https://img.shields.io/badge/Instagram-%23E4405F.svg?style=for-the-badge&logo=Instagram&logoColor=white)](https://www.instagram.com/mastashake08)
@@ -143,6 +175,26 @@ Connect with me on social media:
 - [![X (Twitter)](https://img.shields.io/badge/X-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/jyroneparker)
 - [![Website](https://img.shields.io/badge/Website-%23000000.svg?style=for-the-badge&logo=About.me&logoColor=white)](https://jyroneparker.com)
 
+---
+
+## Support / Funding
+
+If you find ShakeFace useful, please consider supporting the project:
+
+- [GitHub Sponsors](https://github.com/sponsors/mastashake08)
+- [Patreon](https://www.patreon.com/mastashake08)
+- [Ko-fi](https://ko-fi.com/mastashake08)
+- [Liberapay](https://liberapay.com/mastashake08)
+- [Cash App](https://cash.app/$mastashake08)
+
+Your support helps maintain and improve this project!
+
+---
+
 ## License
 
-MIT License
+This software is free to use for hobbyist programmers and developers, free of charge, provided that proper attribution is given to the original author.
+
+Any commercial use of this software is strictly prohibited without a separate license contract. For commercial licensing, please contact the author.
+
+Copyright (c) 2025 Jyrone "Mastashake" Parker <jyrone@jyroneparker.com>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,35 @@
 {
   "name": "@mastashake08/shake-face",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mastashake08/shake-face",
-      "version": "0.9.0",
+      "version": "1.0.0",
       "funding": [
         {
-          "custom": [
-            "https://cash.app/$mastashake08"
-          ],
-          "github": "https://github.com/sponsors/mastashake08",
-          "ko-fi": "https://ko-fi.com/mastashake08",
-          "liberapay": "https://liberapay.com/mastashake08",
-          "patreon": "https://www.patreon.com/mastashake08"
+          "type": "github",
+          "url": "https://github.com/sponsors/mastashake08"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/mastashake08"
+        },
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/mastashake08"
+        },
+        {
+          "type": "liberapay",
+          "url": "https://liberapay.com/mastashake08"
+        },
+        {
+          "type": "custom",
+          "url": "https://cash.app/$mastashake08"
         }
       ],
-      "license": "MIT",
+      "license": "Shake License 1.0",
       "dependencies": {
         "@mastashake08/shake-canvas": "0.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,17 +1,30 @@
 {
   "name": "@mastashake08/shake-face",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "ShakeFace is a JavaScript package that provides functionality for detecting and applying filters to faces in images or video frames. It includes features such as detecting faces in images, applying filters to detected faces, and creating streams for real-time face detection and filter application.",
   "author": "Jyrone Parker <jyrone.parker@gmail.com>",
-  "funding": [{
-    "github": "https://github.com/sponsors/mastashake08",
-    "patreon": "https://www.patreon.com/mastashake08",
-    "ko-fi": "https://ko-fi.com/mastashake08",
-    "liberapay": "https://liberapay.com/mastashake08",
-    "custom": [
-      "https://cash.app/$mastashake08"
-    ]
-  }],
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/mastashake08"
+    },
+    {
+      "type": "patreon",
+      "url": "https://www.patreon.com/mastashake08"
+    },
+    {
+      "type": "ko-fi",
+      "url": "https://ko-fi.com/mastashake08"
+    },
+    {
+      "type": "liberapay",
+      "url": "https://liberapay.com/mastashake08"
+    },
+    {
+      "type": "custom",
+      "url": "https://cash.app/$mastashake08"
+    }
+  ],
   "main": "index.js",
   "module": "index.js",
   "scripts": {
@@ -28,7 +41,26 @@
     "url": "https://github.com/mastashake08/shake-face/issues"
   },
   "keywords": [
-    "face-detection-api"
+    "face-detection-api",
+    "face detection",
+    "face filters",
+    "face recognition",
+    "image processing",
+    "video processing",
+    "javascript",
+    "webcam",
+    "face replacement",
+    "real-time",
+    "face effects",
+    "face tracking",
+    "canvas",
+    "media",
+    "browser",
+    "ai",
+    "machine learning",
+    "computer vision",
+    "augmented reality",
+    "photo editing"
   ],
   "dependencies": {
     "@mastashake08/shake-canvas": "0.0.2"
@@ -49,5 +81,5 @@
   "files": [
     "src"
   ],
-  "license": "MIT"
+  "license": "Shake License 1.0"
 }


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
Whilst watching a YouTube video I noticed the creator was a potato but kept her eyes and mouth on the animation. Wanted to implement that with FaceDetector Landmarks

## What is the current behavior?

This is an enhancement

## What is the new behavior?
When the replace function is called and the keepLandmarks parameter is set to true, then it will keep the users eyes and mouth

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [ ] Tests
- [x] Documentation

<!--
Any additional comments? Thank you for contributing!
-->
